### PR TITLE
Updated telephone field validation.

### DIFF
--- a/docs/v1/tel-field.md
+++ b/docs/v1/tel-field.md
@@ -33,7 +33,7 @@ validation: (value: FieldValue, data: FormData, required: boolean) => true | str
 **Default value**
 
 ```js
-public telFormat = /^\+[1-9]\d{1,14}$/;
+public telFormat = /^\d{7,15}$/;
 
 validation: (value, data, required) => {
     if (required && !value) return 'This field is required';

--- a/packages/core/src/fields/telField.ts
+++ b/packages/core/src/fields/telField.ts
@@ -22,8 +22,8 @@ export class TelField extends Field {
     className: INPUT_CLASS_DEFAULT,
   };
 
-  public telFormat = /^\+[1-9]\d{1,14}$/;
-
+  public telFormat = /^\d{7,15}$/;
+  
   constructor(parent: HTMLElement, form: Form, options: FieldOptions) {
     super(parent, form, options);
     this.initializeOptions(options);


### PR DESCRIPTION
Removed + symbol and 1st number requirement, size can be between 7-15 characters.
Changes reflected in telephone field docs.